### PR TITLE
Make a and b transponder values contribute to vessel polygon size

### DIFF
--- a/modeling/src/modeling.rs
+++ b/modeling/src/modeling.rs
@@ -31,11 +31,11 @@ impl<const CRS: u64> LineTriangle<CRS> {
 
         let b_start_m = DateTime::<Utc>::from_timestamp_secs(self.line.start().m as i64)
             .expect("error ;(")
-            - vessel_speed(&self.line, self.b, line_meters); // The time when a ship transponder reached the start edge of its ship polygon: polygon.line.from.m = line.from.m - (how long it takes the ship to travel 'b' distance)
+            - time_to_travel_distance(&self.line, self.b, line_meters); // The time when a ship transponder reached the start edge of its ship polygon: polygon.line.from.m = line.from.m - (how long it takes the ship to travel 'b' distance)
 
         let a_end_m = DateTime::<Utc>::from_timestamp_secs(self.line.end().m as i64)
             .expect("error ;(")
-            + vessel_speed(&self.line, self.a, line_meters); // The time when a ship transponder reached the end edge of its ship polygon: polygon.line.to.m = line.to.m + (how long it takes the ship to travel 'a' distance)
+            + time_to_travel_distance(&self.line, self.a, line_meters); // The time when a ship transponder reached the end edge of its ship polygon: polygon.line.to.m = line.to.m + (how long it takes the ship to travel 'a' distance)
 
         let probe_m = probe_timestamp(
             b_start_m.timestamp() as f64,
@@ -157,7 +157,7 @@ pub fn probe_timestamp(start_m: f64, delta_m: f64, ratio: f64) -> DateTime<Utc> 
         .expect("ratio er fucked")
 }
 
-pub fn vessel_speed<const CRS: u64>(
+pub fn time_to_travel_distance<const CRS: u64>(
     line: &LineM<CRS>,
     distance: f64,
     line_meters: f64,

--- a/modeling/src/modeling.rs
+++ b/modeling/src/modeling.rs
@@ -1,10 +1,10 @@
 use std::ops::Div;
 
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Duration, TimeDelta, Utc};
 use geo::{Coord, Distance, InterpolatePoint, Vector2DOps, coord, point};
 use geo_traits::{CoordTrait, LineTrait};
-use geo_types::geometry::Triangle;
-use linesonmaps::types::{linem::LineM, pointm::PointM};
+use geo_types::geometry::{Line, Triangle};
+use linesonmaps::types::{coordm::CoordM, linem::LineM, pointm::PointM};
 
 #[derive(Debug)]
 pub struct LineTriangle<const CRS: u64> {
@@ -14,30 +14,56 @@ pub struct LineTriangle<const CRS: u64> {
     pub b: f64,
     pub c: f64,
     pub d: f64,
+    pub ba_line: Line,
 }
 
 impl<const CRS: u64> LineTriangle<CRS> {
     pub fn point_occupation(&self, ba: f64, bb: f64, bc: f64) -> (DateTime<Utc>, DateTime<Utc>) {
-        let probe_vec = probe_vector(&self.line, self.triangle, ba, bb, bc);
+        let probe_vec = probe_vector(&self.ba_line, self.triangle, ba, bb, bc);
 
         let ratio = probe_ratio(
             probe_vec,
-            self.line.end().x() - self.line.start().x(),
-            self.line.end().y() - self.line.start().y(),
-        );
-
-        let probe_m = probe_timestamp(
-            self.line.start().m,
-            self.line.end().m - self.line.start().m,
-            ratio,
+            self.ba_line.end.x() - self.ba_line.start.x(),
+            self.ba_line.end.y() - self.ba_line.start.y(),
         );
 
         let line_meters = meters_between_points(self.line.from, self.line.to);
 
+        let b_start_m = DateTime::<Utc>::from_timestamp_secs(self.line.start().m as i64)
+            .expect("error ;(")
+            - vessel_speed(&self.line, self.b, line_meters); // The time when a ship transponder reached the start edge of its ship polygon: polygon.line.from.m = line.from.m - (how long it takes the ship to travel 'b' distance)
+
+        let a_end_m = DateTime::<Utc>::from_timestamp_secs(self.line.end().m as i64)
+            .expect("error ;(")
+            + vessel_speed(&self.line, self.a, line_meters); // The time when a ship transponder reached the end edge of its ship polygon: polygon.line.to.m = line.to.m + (how long it takes the ship to travel 'a' distance)
+
+        let probe_m = probe_timestamp(
+            b_start_m.timestamp() as f64,
+            (a_end_m.timestamp() - b_start_m.timestamp()) as f64,
+            ratio,
+        );
+
+        let ba_meters = meters_between_points(
+            PointM::<4326> {
+                coord: CoordM::<4326> {
+                    x: self.ba_line.start.x,
+                    y: self.ba_line.start.y,
+                    m: b_start_m.timestamp() as f64,
+                },
+            },
+            PointM::<4326> {
+                coord: CoordM::<4326> {
+                    x: self.ba_line.end.x,
+                    y: self.ba_line.end.y,
+                    m: a_end_m.timestamp() as f64,
+                },
+            },
+        );
+
         probe_occupation(
             probe_m,
-            self.line.end().m - self.line.start().m,
-            line_meters,
+            (a_end_m.timestamp() - b_start_m.timestamp()) as f64,
+            ba_meters,
             self.a,
             self.b,
         )
@@ -64,31 +90,43 @@ pub fn line_to_triangle_pair<const CRS: u64>(
     //let vec_orth_c = vec![-dy, dx]; // orthogonal vector of the line, representative of c width
     //let vec_orth_d = vec![dy, -dx]; // orthogonal vector of the line, representative of d width
 
+    let b_start = geo::algorithm::line_measures::metric_spaces::Geodesic.point_at_distance_between(
+        point!(line.start().x_y()),
+        point!(x: line.start().x()-dx, y: line.start().y()-dy),
+        b,
+    );
+
+    let a_end = geo::algorithm::line_measures::metric_spaces::Geodesic.point_at_distance_between(
+        point!(line.end().x_y()),
+        point!(x: line.end().x()+dx, y: line.end().y()+dy),
+        a,
+    );
+
     let start_point_c = geo::algorithm::line_measures::metric_spaces::Geodesic
         .point_at_distance_between(
-            point!(line.start().x_y()),
-            point!(x: line.start().x()+(-dy), y: line.start().y()+(dx)),
+            point!(b_start.x_y()),
+            point!(x: b_start.x()+(-dy), y: b_start.y()+(dx)),
             c,
         ); // Point 
 
     let start_point_d = geo::algorithm::line_measures::metric_spaces::Geodesic
         .point_at_distance_between(
-            point!(line.start().x_y()),
-            point!(x: line.start().x()+(dy), y: line.start().y()+(-dx)),
+            point!(b_start.x_y()),
+            point!(x: b_start.x()+(dy), y: b_start.y()+(-dx)),
             d,
         );
 
     let end_point_c = geo::algorithm::line_measures::metric_spaces::Geodesic
         .point_at_distance_between(
-            point!(line.end().x_y()),
-            point!(x: line.end().x()+(-dy), y: line.end().y()+(dx)),
+            point!(a_end.x_y()),
+            point!(x: a_end.x()+(-dy), y: a_end.y()+(dx)),
             c,
         );
 
     let end_point_d = geo::algorithm::line_measures::metric_spaces::Geodesic
         .point_at_distance_between(
-            point!(line.end().x_y()),
-            point!(x: line.end().x()+(dy), y: line.end().y()+(-dx)),
+            point!(a_end.x_y()),
+            point!(x: a_end.x()+(dy), y: a_end.y()+(-dx)),
             d,
         );
 
@@ -100,6 +138,7 @@ pub fn line_to_triangle_pair<const CRS: u64>(
             b,
             c,
             d,
+            ba_line: Line::new(b_start, a_end),
         },
         LineTriangle {
             triangle: Triangle::new(start_point_d.0, end_point_c.0, end_point_d.0),
@@ -108,6 +147,7 @@ pub fn line_to_triangle_pair<const CRS: u64>(
             b,
             c,
             d,
+            ba_line: Line::new(b_start, a_end),
         },
     )
 }
@@ -115,6 +155,17 @@ pub fn line_to_triangle_pair<const CRS: u64>(
 pub fn probe_timestamp(start_m: f64, delta_m: f64, ratio: f64) -> DateTime<Utc> {
     DateTime::<Utc>::from_timestamp_secs((delta_m * ratio) as i64 + start_m as i64)
         .expect("ratio er fucked")
+}
+
+pub fn vessel_speed<const CRS: u64>(
+    line: &LineM<CRS>,
+    distance: f64,
+    line_meters: f64,
+) -> TimeDelta {
+    if line_meters == 0. {
+        return Duration::seconds(0);
+    }
+    Duration::seconds(((line.end().m - line.start().m) / line_meters * distance) as i64) // how long does it take the vessel to travel 'distance', based on calculated speed
 }
 
 pub fn probe_occupation(
@@ -145,15 +196,9 @@ pub fn meters_between_points<const CRS: u64>(origin: PointM<CRS>, destination: P
     geo::algorithm::line_measures::metric_spaces::Geodesic.distance(origin, destination)
 }
 
-pub fn probe_vector<const CRS: u64>(
-    line: &LineM<CRS>,
-    triangle: Triangle,
-    ba: f64,
-    bb: f64,
-    bc: f64,
-) -> Coord<f64> {
+pub fn probe_vector(ba_line: &Line, triangle: Triangle, ba: f64, bb: f64, bc: f64) -> Coord<f64> {
     let coord = barycentric_to_cartesian(triangle, ba, bb, bc);
-    coord! {x: coord.x-line.start().x, y: coord.y-line.start().y}
+    coord! {x: coord.x-ba_line.start().x, y: coord.y-ba_line.start().y}
 }
 
 // ratio of how far along the line the probe point is
@@ -177,7 +222,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn half_way_test() {
+    fn half_way_test_with_matching_a_b() {
         let start_m =
             DateTime::parse_from_str("2024-01-01 00:00:00 +0000", "%Y-%m-%d %H:%M:%S%.3f %z")
                 .unwrap()
@@ -192,11 +237,16 @@ mod tests {
             .to_vec();
         let line = LineM::<4326>::from((coords[0], coords[1]));
 
-        let a = line_to_triangle_pair(&line, 1.0, 1.0, 10.0, 10.0);
+        let a = line_to_triangle_pair(&line, 10.0, 10.0, 10.0, 10.0);
+
         assert_eq!(
-            a.0.point_occupation(1. / 2., 0., 1. / 2.).0.timestamp() as f64 - start_m,
+            (a.0.point_occupation(1. / 2., 0., 1. / 2.).1.timestamp() as f64 - start_m
+                + a.0.point_occupation(1. / 2., 0., 1. / 2.).0.timestamp() as f64
+                - start_m)
+                / 2.0,
             (end_m - start_m) / 2.0
-        )
+        ) // point_occupation returns a start and end time for a probe, if we are probing the middle and a = b (this test),
+        // then (∆probe_start_time+∆probe_endtime)/2 should be = ∆delta_m / 2
     }
 
     #[test]


### PR DESCRIPTION
Extends `line_to_triangle_pair()` to use a and b values (previously only c and d) when constructing the two `LineTriangle`s.
- `point_occupation()` already supported abcd values but this pr also makes the probe-able area larger by a+b in length.

Closes not #70 as the current orientation method uses ∆x and ∆y to compute the vessel direction vector, which it cannot do when: ∆x = ∆y = 0